### PR TITLE
Issue #9, prettier settings

### DIFF
--- a/DevKeyboard.ahk
+++ b/DevKeyboard.ahk
@@ -115,64 +115,67 @@ IfNotExist %A_AppData%\DevKeyboard\OpenAuto.txt
 
 
 Gui, Add, Text,, Hold Down Time:
-Gui, Add, Edit, R1 vTimeSetting
 
 Gui, Add, Text,, Edit G:
-Gui, Add, Edit, r1 vGEdit
 Gui, Add, Text,, Edit H:
-Gui, Add, Edit, r1 vHEdit
 Gui, Add, Text,, Edit F:
-Gui, Add, Edit, r1 vFEdit
 Gui, Add, Text,, Edit J:
-Gui, Add, Edit, r1 vJEdit
 Gui, Add, Text,, Edit D:
-Gui, Add, Edit, r1 vDEdit
 Gui, Add, Text,, Edit K:
-Gui, Add, Edit, r1 vKEdit
 Gui, Add, Text,, Edit S:
-Gui, Add, Edit, r1 vSEdit
 Gui, Add, Text,, Edit A:
-Gui, Add, Edit, r1 vAEdit
-Gui, Add, Text,ym, Edit L:
-Gui, Add, Edit, r1 vLEdit
+Gui, Add, Text,, Edit L:
 Gui, Add, Text,, Edit Z:
-Gui, Add, Edit, r1 vZEdit
 Gui, Add, Text,, Edit X:
-Gui, Add, Edit, r1 vXEdit
 Gui, Add, Text,, Edit C:
-Gui, Add, Edit, r1 vCEdit
-Gui, Add, Text,, Edit V:
-Gui, Add, Edit, r1 vVEdit
-Gui, Add, Text,, Edit B:
-Gui, Add, Edit, r1 vBEdit
-Gui, Add, Text,, Edit N:
-Gui, Add, Edit, r1 vNEdit
-Gui, Add, Text,, Edit M:
-Gui, Add, Edit, r1 vMEdit
-Gui, Add, Text,, Edit Comma:
-Gui, Add, Edit, r1 vCommaEdit
-Gui, Add, Text,ym, Edit Q:
-Gui, Add, Edit, r1 vQEdit
-Gui, Add, Text,, Edit W:
-Gui, Add, Edit, r1 vWEdit
-Gui, Add, Text,, Edit E:
-Gui, Add, Edit, r1 vEEdit
-Gui, Add, Text,, Edit R:
-Gui, Add, Edit, r1 vREdit
-Gui, Add, Text,, Edit T:
-Gui, Add, Edit, r1 vTEdit
-Gui, Add, Text,, Edit Y:
-Gui, Add, Edit, r1 vYEdit
-Gui, Add, Text,, Edit U:
-Gui, Add, Edit, r1 vUEdit
-Gui, Add, Text,, Edit I:
-Gui, Add, Edit, r1 vIEdit
-Gui, Add, Text,, Edit O:
-Gui, Add, Edit, r1 vOEdit
-Gui, Add, Text,ym, Edit P:
-Gui, Add, Edit, r1 vPEdit
+Gui, Add, Text,, Edit Q:
 
-Gui, Add, Checkbox, vSemicolonEdit, Enable semicolon`nshortcut key
+Gui, Add, Edit, R1 vTimeSetting ym
+Gui, Add, Edit, r1 vGEdit
+Gui, Add, Edit, r1 vHEdit
+Gui, Add, Edit, r1 vFEdit
+Gui, Add, Edit, r1 vJEdit
+Gui, Add, Edit, r1 vDEdit
+Gui, Add, Edit, r1 vKEdit
+Gui, Add, Edit, r1 vSEdit
+Gui, Add, Edit, r1 vAEdit
+Gui, Add, Edit, r1 vLEdit 
+Gui, Add, Edit, r1 vZEdit
+Gui, Add, Edit, r1 vXEdit
+Gui, Add, Edit, r1 vCEdit
+Gui, Add, Edit, r1 vQEdit
+
+Gui, Add, Text,ym, Edit W:
+Gui, Add, Text,, Edit E:
+Gui, Add, Text,, Edit R:
+Gui, Add, Text,, Edit T:
+Gui, Add, Text,, Edit Y:
+Gui, Add, Text,, Edit U:
+Gui, Add, Text,, Edit I:
+Gui, Add, Text,, Edit O:
+Gui, Add, Text,, Edit P:
+Gui, Add, Text,, Edit V:
+Gui, Add, Text,, Edit B:
+Gui, Add, Text,, Edit N:
+Gui, Add, Text,, Edit M:
+Gui, Add, Text,, Edit Comma:
+
+Gui, Add, Edit, r1 vWEdit ym
+Gui, Add, Edit, r1 vEEdit
+Gui, Add, Edit, r1 vREdit
+Gui, Add, Edit, r1 vTEdit
+Gui, Add, Edit, r1 vYEdit
+Gui, Add, Edit, r1 vUEdit
+Gui, Add, Edit, r1 vIEdit
+Gui, Add, Edit, r1 vOEdit
+Gui, Add, Edit, r1 vPEdit
+Gui, Add, Edit, r1 vVEdit
+Gui, Add, Edit, r1 vBEdit
+Gui, Add, Edit, r1 vNEdit
+Gui, Add, Edit, r1 vMEdit
+Gui, Add, Edit, r1 vCommaEdit
+
+Gui, Add, Checkbox, vSemicolonEdit ym, Enable semicolon`nshortcut key
 Gui, Add, Checkbox, vOpenAutoEdit, Enable AutoStart
 Gui, Add, Button, gYouPressed, Save
 Gui, Add, Text,, DevKeyboard Version 1.4
@@ -337,7 +340,7 @@ if var FileContentsOpenAuto = "true"
 }
 
 Gui, +Resize
-Gui, Show, w535 h440, Settings
+Gui, Show,, Settings
 return
 
 YouPressed:

--- a/DevKeyboard.ahk
+++ b/DevKeyboard.ahk
@@ -112,8 +112,6 @@ IfNotExist %A_AppData%\DevKeyboard\P.txt
 IfNotExist %A_AppData%\DevKeyboard\OpenAuto.txt 
 	FileAppend,, %A_AppData%\DevKeyboard\OpenAuto.txt 
 
-
-
 Gui, Add, Text,, Edit G:
 Gui, Add, Text,, Edit H:
 Gui, Add, Text,, Edit F:
@@ -172,16 +170,20 @@ Gui, Add, Edit, r1 vBEdit
 Gui, Add, Edit, r1 vNEdit
 Gui, Add, Edit, r1 vMEdit
 
-Gui, Add, Text, ym, Edit Comma:
-Gui, Add, Edit, r1 vCommaEdit
-
+; +Section creates a "section", so further columning done with ys or ym
+; (instead of ym and xm) works relative to only that section and the objects 
+; int it. In short, useful for nesting columns.
+Gui, Add, Text, ym +Section, Edit Comma:
 Gui, Add, Text,, Hold Down Time:
+
+
+Gui, Add, Edit, r1 vCommaEdit ym
 Gui, Add, Edit, R1 vTimeSetting 
 
-Gui, Add, Checkbox, vSemicolonEdit, Enable semicolon`nshortcut key
+Gui, Add, Text, xs, DevKeyboard Version 1.4
+Gui, Add, Checkbox, vSemicolonEdit, Enable semicolon shortcut key
 Gui, Add, Checkbox, vOpenAutoEdit, Enable AutoStart
 Gui, Add, Button, gYouPressed, Save
-Gui, Add, Text,, DevKeyboard Version 1.4
 
 FileRead, FileContents, %A_AppData%\DevKeyboard\time.txt
 time = %FileContents%

--- a/DevKeyboard.ahk
+++ b/DevKeyboard.ahk
@@ -114,8 +114,6 @@ IfNotExist %A_AppData%\DevKeyboard\OpenAuto.txt
 
 
 
-Gui, Add, Text,, Hold Down Time:
-
 Gui, Add, Text,, Edit G:
 Gui, Add, Text,, Edit H:
 Gui, Add, Text,, Edit F:
@@ -130,8 +128,8 @@ Gui, Add, Text,, Edit X:
 Gui, Add, Text,, Edit C:
 Gui, Add, Text,, Edit Q:
 
-Gui, Add, Edit, R1 vTimeSetting ym
-Gui, Add, Edit, r1 vGEdit
+
+Gui, Add, Edit, r1 vGEdit ym
 Gui, Add, Edit, r1 vHEdit
 Gui, Add, Edit, r1 vFEdit
 Gui, Add, Edit, r1 vJEdit
@@ -145,7 +143,7 @@ Gui, Add, Edit, r1 vXEdit
 Gui, Add, Edit, r1 vCEdit
 Gui, Add, Edit, r1 vQEdit
 
-Gui, Add, Text,ym, Edit W:
+Gui, Add, Text, ym, Edit W:
 Gui, Add, Text,, Edit E:
 Gui, Add, Text,, Edit R:
 Gui, Add, Text,, Edit T:
@@ -158,7 +156,7 @@ Gui, Add, Text,, Edit V:
 Gui, Add, Text,, Edit B:
 Gui, Add, Text,, Edit N:
 Gui, Add, Text,, Edit M:
-Gui, Add, Text,, Edit Comma:
+
 
 Gui, Add, Edit, r1 vWEdit ym
 Gui, Add, Edit, r1 vEEdit
@@ -173,9 +171,14 @@ Gui, Add, Edit, r1 vVEdit
 Gui, Add, Edit, r1 vBEdit
 Gui, Add, Edit, r1 vNEdit
 Gui, Add, Edit, r1 vMEdit
+
+Gui, Add, Text, ym, Edit Comma:
 Gui, Add, Edit, r1 vCommaEdit
 
-Gui, Add, Checkbox, vSemicolonEdit ym, Enable semicolon`nshortcut key
+Gui, Add, Text,, Hold Down Time:
+Gui, Add, Edit, R1 vTimeSetting 
+
+Gui, Add, Checkbox, vSemicolonEdit, Enable semicolon`nshortcut key
 Gui, Add, Checkbox, vOpenAutoEdit, Enable AutoStart
 Gui, Add, Button, gYouPressed, Save
 Gui, Add, Text,, DevKeyboard Version 1.4


### PR DESCRIPTION
Rearranged the GUI in the settings window to make it look better and waste less space. This was accomplished using these methods: 
1. Let the labels and input boxes be in separate columns beside each other, instead of the same column as it was before.
2. Took the two wider setting elements ("Edit comma" and "Hold down time") and removed them from the main button settings. That way every other button setting label did not have to be extended to align well, and we saved a lot of space.
3. Special care was taken for the "misc" elements at the end (check boxes, save button, version label...), so that they could fill out the horizontal space left by the two columns above. This was accomplished using AHK "Sections", which are further explained in the comments.

The one thing I think still is missing is having the "misc options" (or at least the save button and/or the version text) be aligned to the bottom right corner, but I was not able to accomplish that.
